### PR TITLE
fix: github repo clone defaults

### DIFF
--- a/terraform/secure-kube/main.tf
+++ b/terraform/secure-kube/main.tf
@@ -128,7 +128,7 @@ resource "null_resource" "create_kubernetes_toolchain" {
       SERVICE_API_KEY   = data.ibm_iam_api_key.service_api_key.apikey
       SM_NAME           = var.sm_name
       SM_SERVICE_NAME   = var.sm_service_name == "compliance-ci-secrets-manager" ? "compliance-ci-secrets-manager" : var.sm_service_name
-      GITHUB_TOKEN      = var.github_token
+      GITLAB_TOKEN      = var.gitlab_token
       TEKTON_CAT_REPO   = var.tekton_catalog_repo
     }
   } 

--- a/terraform/secure-kube/main.tf
+++ b/terraform/secure-kube/main.tf
@@ -7,41 +7,8 @@ provider "ibm" {
   ibmcloud_api_key  = var.ibmcloud_api_key
 }
 
-provider "gitlab" {
-  version   = "~> 3.6"
-  base_url  = "https://us-south.git.cloud.ibm.com/"
-  token     = var.gitlab_token
-}
-
 provider "null" {
   version = "~> 3.1"
-}
-
-resource "gitlab_project" "issues_repo" {
-  count               = var.issues_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-incident-issues" ? 1 : 0
-  name                = "compliance-issues-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  description         = "Repo for storing compliance issues"
-  visibility_level    = "private"
-  template_name       = "one-pipeline/compliance-incident-issues"
-  use_custom_template = true
-}
-
-resource "gitlab_project" "inventory_repo" {
-  count               = var.inventory_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-inventory" ? 1 : 0
-  name                = "compliance-inventory-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  description         = "Repo for storing compliance inventory"
-  visibility_level    = "private"
-  template_name       = "one-pipeline/compliance-inventory"
-  use_custom_template = true
-}
-
-resource "gitlab_project" "evidence_repo" {
-  count               = var.evidence_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-evidence-locker" ? 1 : 0
-  name                = "compliance-evidence-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  description         = "Repo for storing compliance evidence"
-  visibility_level    = "private"
-  template_name       = "one-pipeline/compliance-evidence-locker"
-  use_custom_template = true
 }
 
 data "ibm_resource_group" "cos_group" {
@@ -98,7 +65,6 @@ resource "null_resource" "create_kubernetes_toolchain" {
       REGION            =  var.region
       TOOLCHAIN_TEMPLATE_REPO = var.toolchain_template_repo
       APPLICATION_REPO  = var.application_repo
-      PIPELINE_REPO     = var.pipeline_repo
       RESOURCE_GROUP    = var.resource_group
       API_KEY           = var.ibmcloud_api_key
       CLUSTER_NAME      = "compliance-latest"
@@ -108,16 +74,12 @@ resource "null_resource" "create_kubernetes_toolchain" {
       PIPELINE_TYPE     = var.pipeline_type
       BRANCH            = var.branch
       APP_NAME          = var.app_name == "compliance-app-<timestamp>" ? "compliance-app-${formatdate("YYYYMMDDhhmm", timestamp())}" : var.app_name
-      ISSUES_REPO       = var.issues_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-incident-issues" ? gitlab_project.issues_repo[0].id : var.issues_repo
-      INVENTORY_REPO    = var.inventory_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-inventory" ? gitlab_project.inventory_repo[0].id : var.inventory_repo
-      EVIDENCE_REPO     = var.evidence_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-evidence-locker" ? gitlab_project.evidence_repo[0].id : var.evidence_repo
       COS_BUCKET_NAME   = "${element(split(":", ibm_cos_bucket.cos_bucket.crn),9)}"
       COS_URL           = var.cos_url
       SERVICE_API_KEY   = data.ibm_iam_api_key.service_api_key.apikey
       SM_NAME           = var.sm_name
       SM_SERVICE_NAME   = var.sm_service_name == "compliance-ci-secrets-manager" ? "compliance-ci-secrets-manager" : var.sm_service_name
       GITLAB_TOKEN      = var.gitlab_token
-      TEKTON_CAT_REPO   = var.tekton_catalog_repo
     }
   } 
 }

--- a/terraform/secure-kube/main.tf
+++ b/terraform/secure-kube/main.tf
@@ -57,6 +57,19 @@ data "ibm_resource_group" "group" {
   name = var.resource_group
 }
 
+resource "ibm_container_cluster" "cluster" {
+  count             = var.cluster_name == "compliance-cluster" ? 1 : 0
+  name              = var.cluster_name
+  datacenter        = var.datacenter
+  default_pool_size = var.default_pool_size
+  machine_type      = var.machine_type
+  hardware          = var.hardware
+  kube_version      = var.kube_version
+  public_vlan_id    = var.public_vlan_num
+  private_vlan_id   = var.private_vlan_num
+  resource_group_id = data.ibm_resource_group.group.id
+}
+
 resource "null_resource" "create_kubernetes_toolchain" {
   provisioner "local-exec" {
     command = "${path.cwd}/scripts/create-toolchain.sh"
@@ -67,8 +80,8 @@ resource "null_resource" "create_kubernetes_toolchain" {
       APPLICATION_REPO  = var.application_repo
       RESOURCE_GROUP    = var.resource_group
       API_KEY           = var.ibmcloud_api_key
-      CLUSTER_NAME      = "compliance-latest"
-      CLUSTER_NAMESPACE = "default"
+      CLUSTER_NAME      = var.cluster_name
+      CLUSTER_NAMESPACE = var.cluster_namespace
       REGISTRY_NAMESPACE  = var.registry_namespace
       TOOLCHAIN_NAME    = var.toolchain_name == "compliance-ci-toolchain-<timestamp>" ? "compliance-ci-toolchain-${formatdate("YYYYMMDDhhmm", timestamp())}" : var.toolchain_name
       PIPELINE_TYPE     = var.pipeline_type

--- a/terraform/secure-kube/main.tf
+++ b/terraform/secure-kube/main.tf
@@ -8,6 +8,7 @@ provider "ibm" {
 }
 
 provider "gitlab" {
+  version   = "~> 3.6"
   base_url  = "https://us-south.git.cloud.ibm.com/"
   token     = var.gitlab_token
 }
@@ -16,28 +17,43 @@ provider "null" {
   version = "~> 3.1"
 }
 
-resource "gitlab_project" "issues_repo" {
-  count             = var.issues_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-incident-issues" ? 1 : 0
-  name              = "compliance-issues-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  description       = "Repo for storing compliance issues"
-  visibility_level  = "private"
-  template_name     = "one-pipeline/compliance-incident-issues"
+resource "github_repository" "issues_repo" {
+  count       = var.issues_repo == "https://github.ibm.com/one-pipeline/compliance-incident-issues" ? 1 : 0
+  name        = "compliance-issues-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  description = "Repo for storing compliance issues"
+  visibility  = "private"
+  vulnerability_alerts  = true
+
+  template {
+    owner      = "one-pipeline"
+    repository = "compliance-incident-issues"
+  }
 }
 
-resource "gitlab_project" "inventory_repo" {
-  count             = var.inventory_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-inventory" ? 1 : 0
-  name              = "compliance-inventory-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  description       = "Repo for storing compliance inventory"
-  visibility_level  = "private"
-  template_name     = "one-pipeline/compliance-inventory"
+resource "github_repository" "inventory_repo" {
+  count       = var.inventory_repo == "https://github.ibm.com/one-pipeline/compliance-inventory" ? 1 : 0
+  name        = "compliance-inventory-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  description = "Repo for storing compliance inventory"
+  visibility  = "private"
+  vulnerability_alerts  = true
+
+  template {
+    owner      = "one-pipeline"
+    repository = "compliance-inventory"
+  }
 }
 
-resource "gitlab_project" "evidence_repo" {
-  count             = var.evidence_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-evidence-locker" ? 1 : 0
-  name              = "compliance-evidence-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  description       = "Repo for storing compliance evidence"
-  visibility_level  = "private"
-  template_name     = "one-pipeline/compliance-evidence-locker"
+resource "github_repository" "evidence_repo" {
+  count       = var.evidence_repo == "https://github.ibm.com/one-pipeline/compliance-evidence-locker" ? 1 : 0
+  name        = "compliance-evidence-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  description = "Repo for storing compliance evidence"
+  visibility  = "private"
+  vulnerability_alerts  = true
+
+  template {
+    owner      = "one-pipeline"
+    repository = "compliance-evidence-locker"
+  }
 }
 
 data "ibm_resource_group" "cos_group" {

--- a/terraform/secure-kube/main.tf
+++ b/terraform/secure-kube/main.tf
@@ -7,53 +7,41 @@ provider "ibm" {
   ibmcloud_api_key  = var.ibmcloud_api_key
 }
 
-provider "github" {
-  version   = "~> 4.12"
-  base_url  = "https://github.ibm.com/"
-  token     = var.github_token
+provider "gitlab" {
+  version   = "~> 3.6"
+  base_url  = "https://us-south.git.cloud.ibm.com/"
+  token     = var.gitlab_token
 }
 
 provider "null" {
   version = "~> 3.1"
 }
 
-resource "github_repository" "issues_repo" {
-  count       = var.issues_repo == "https://github.ibm.com/one-pipeline/compliance-incident-issues" ? 1 : 0
-  name        = "compliance-issues-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  description = "Repo for storing compliance issues"
-  visibility  = "private"
-  vulnerability_alerts  = true
-
-  template {
-    owner      = "one-pipeline"
-    repository = "compliance-incident-issues"
-  }
+resource "gitlab_project" "issues_repo" {
+  count               = var.issues_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-incident-issues" ? 1 : 0
+  name                = "compliance-issues-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  description         = "Repo for storing compliance issues"
+  visibility_level    = "private"
+  template_name       = "one-pipeline/compliance-incident-issues"
+  use_custom_template = true
 }
 
-resource "github_repository" "inventory_repo" {
-  count       = var.inventory_repo == "https://github.ibm.com/one-pipeline/compliance-inventory" ? 1 : 0
-  name        = "compliance-inventory-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  description = "Repo for storing compliance inventory"
-  visibility  = "private"
-  vulnerability_alerts  = true
-
-  template {
-    owner      = "one-pipeline"
-    repository = "compliance-inventory"
-  }
+resource "gitlab_project" "inventory_repo" {
+  count               = var.inventory_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-inventory" ? 1 : 0
+  name                = "compliance-inventory-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  description         = "Repo for storing compliance inventory"
+  visibility_level    = "private"
+  template_name       = "one-pipeline/compliance-inventory"
+  use_custom_template = true
 }
 
-resource "github_repository" "evidence_repo" {
-  count       = var.evidence_repo == "https://github.ibm.com/one-pipeline/compliance-evidence-locker" ? 1 : 0
-  name        = "compliance-evidence-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  description = "Repo for storing compliance evidence"
-  visibility  = "private"
-  vulnerability_alerts  = true
-
-  template {
-    owner      = "one-pipeline"
-    repository = "compliance-evidence-locker"
-  }
+resource "gitlab_project" "evidence_repo" {
+  count               = var.evidence_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-evidence-locker" ? 1 : 0
+  name                = "compliance-evidence-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  description         = "Repo for storing compliance evidence"
+  visibility_level    = "private"
+  template_name       = "one-pipeline/compliance-evidence-locker"
+  use_custom_template = true
 }
 
 data "ibm_resource_group" "cos_group" {
@@ -120,15 +108,15 @@ resource "null_resource" "create_kubernetes_toolchain" {
       PIPELINE_TYPE     = var.pipeline_type
       BRANCH            = var.branch
       APP_NAME          = var.app_name == "compliance-app-<timestamp>" ? "compliance-app-${formatdate("YYYYMMDDhhmm", timestamp())}" : var.app_name
-      ISSUES_REPO       = var.issues_repo == "https://github.ibm.com/one-pipeline/compliance-incident-issues" ? github_repository.issues_repo[0].id : var.issues_repo
-      INVENTORY_REPO    = var.inventory_repo == "https://github.ibm.com/one-pipeline/compliance-inventory" ? github_repository.inventory_repo[0].id : var.inventory_repo
-      EVIDENCE_REPO     = var.evidence_repo == "https://github.ibm.com/one-pipeline/compliance-evidence-locker" ? github_repository.evidence_repo[0].id : var.evidence_repo
+      ISSUES_REPO       = var.issues_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-incident-issues" ? gitlab_project.issues_repo[0].id : var.issues_repo
+      INVENTORY_REPO    = var.inventory_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-inventory" ? gitlab_project.inventory_repo[0].id : var.inventory_repo
+      EVIDENCE_REPO     = var.evidence_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-evidence-locker" ? gitlab_project.evidence_repo[0].id : var.evidence_repo
       COS_BUCKET_NAME   = "${element(split(":", ibm_cos_bucket.cos_bucket.crn),9)}"
       COS_URL           = var.cos_url
       SERVICE_API_KEY   = data.ibm_iam_api_key.service_api_key.apikey
       SM_NAME           = var.sm_name
       SM_SERVICE_NAME   = var.sm_service_name == "compliance-ci-secrets-manager" ? "compliance-ci-secrets-manager" : var.sm_service_name
-      GITHUB_TOKEN      = var.github_token
+      GITLAB_TOKEN      = var.gitlab_token
       TEKTON_CAT_REPO   = var.tekton_catalog_repo
     }
   } 

--- a/terraform/secure-kube/main.tf
+++ b/terraform/secure-kube/main.tf
@@ -9,7 +9,7 @@ provider "ibm" {
 
 provider "github" {
   version   = "~> 4.12"
-  base_url  = "https://github.ibm.com/"
+  base_url  = "https://us-south.git.cloud.ibm.com/"
   token     = var.github_token
 }
 
@@ -18,7 +18,7 @@ provider "null" {
 }
 
 resource "github_repository" "issues_repo" {
-  count       = var.issues_repo == "https://github.ibm.com/one-pipeline/compliance-incident-issues" ? 1 : 0
+  count       = var.issues_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-incident-issues" ? 1 : 0
   name        = "compliance-issues-${formatdate("YYYYMMDDhhmm", timestamp())}"
   description = "Repo for storing compliance issues"
   visibility  = "private"
@@ -31,7 +31,7 @@ resource "github_repository" "issues_repo" {
 }
 
 resource "github_repository" "inventory_repo" {
-  count       = var.inventory_repo == "https://github.ibm.com/one-pipeline/compliance-inventory" ? 1 : 0
+  count       = var.inventory_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-inventory" ? 1 : 0
   name        = "compliance-inventory-${formatdate("YYYYMMDDhhmm", timestamp())}"
   description = "Repo for storing compliance inventory"
   visibility  = "private"
@@ -44,7 +44,7 @@ resource "github_repository" "inventory_repo" {
 }
 
 resource "github_repository" "evidence_repo" {
-  count       = var.evidence_repo == "https://github.ibm.com/one-pipeline/compliance-evidence-locker" ? 1 : 0
+  count       = var.evidence_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-evidence-locker" ? 1 : 0
   name        = "compliance-evidence-${formatdate("YYYYMMDDhhmm", timestamp())}"
   description = "Repo for storing compliance evidence"
   visibility  = "private"
@@ -120,9 +120,9 @@ resource "null_resource" "create_kubernetes_toolchain" {
       PIPELINE_TYPE     = var.pipeline_type
       BRANCH            = var.branch
       APP_NAME          = var.app_name == "compliance-app-<timestamp>" ? "compliance-app-${formatdate("YYYYMMDDhhmm", timestamp())}" : var.app_name
-      ISSUES_REPO       = var.issues_repo == "https://github.ibm.com/one-pipeline/compliance-incident-issues" ? github_repository.issues_repo[0].id : var.issues_repo
-      INVENTORY_REPO    = var.inventory_repo == "https://github.ibm.com/one-pipeline/compliance-inventory" ? github_repository.inventory_repo[0].id : var.inventory_repo
-      EVIDENCE_REPO     = var.evidence_repo == "https://github.ibm.com/one-pipeline/compliance-evidence-locker" ? github_repository.evidence_repo[0].id : var.evidence_repo
+      ISSUES_REPO       = var.issues_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-incident-issues" ? github_repository.issues_repo[0].id : var.issues_repo
+      INVENTORY_REPO    = var.inventory_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-inventory" ? github_repository.inventory_repo[0].id : var.inventory_repo
+      EVIDENCE_REPO     = var.evidence_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-evidence-locker" ? github_repository.evidence_repo[0].id : var.evidence_repo
       COS_BUCKET_NAME   = "${element(split(":", ibm_cos_bucket.cos_bucket.crn),9)}"
       COS_URL           = var.cos_url
       SERVICE_API_KEY   = data.ibm_iam_api_key.service_api_key.apikey

--- a/terraform/secure-kube/main.tf
+++ b/terraform/secure-kube/main.tf
@@ -102,18 +102,6 @@ data "ibm_resource_group" "group" {
   name = var.resource_group
 }
 
-resource "ibm_container_cluster" "cluster" {
-  name              = var.cluster_name
-  datacenter        = var.datacenter
-  default_pool_size = var.default_pool_size
-  machine_type      = var.machine_type
-  hardware          = var.hardware
-  kube_version      = var.kube_version
-  public_vlan_id    = var.public_vlan_num
-  private_vlan_id   = var.private_vlan_num
-  resource_group_id = data.ibm_resource_group.group.id
-}
-
 resource "null_resource" "create_kubernetes_toolchain" {
   provisioner "local-exec" {
     command = "${path.cwd}/scripts/create-toolchain.sh"
@@ -125,8 +113,8 @@ resource "null_resource" "create_kubernetes_toolchain" {
       PIPELINE_REPO     = var.pipeline_repo
       RESOURCE_GROUP    = var.resource_group
       API_KEY           = var.ibmcloud_api_key
-      CLUSTER_NAME      = var.cluster_name
-      CLUSTER_NAMESPACE = var.cluster_namespace
+      CLUSTER_NAME      = "compliance-latest"
+      CLUSTER_NAMESPACE = "default"
       REGISTRY_NAMESPACE  = var.registry_namespace
       TOOLCHAIN_NAME    = var.toolchain_name == "compliance-ci-toolchain-<timestamp>" ? "compliance-ci-toolchain-${formatdate("YYYYMMDDhhmm", timestamp())}" : var.toolchain_name
       PIPELINE_TYPE     = var.pipeline_type

--- a/terraform/secure-kube/main.tf
+++ b/terraform/secure-kube/main.tf
@@ -7,10 +7,9 @@ provider "ibm" {
   ibmcloud_api_key  = var.ibmcloud_api_key
 }
 
-provider "github" {
-  version   = "~> 4.12"
+provider "gitlab" {
   base_url  = "https://us-south.git.cloud.ibm.com/"
-  token     = var.github_token
+  token     = var.gitlab_token
 }
 
 provider "null" {

--- a/terraform/secure-kube/main.tf
+++ b/terraform/secure-kube/main.tf
@@ -7,10 +7,10 @@ provider "ibm" {
   ibmcloud_api_key  = var.ibmcloud_api_key
 }
 
-provider "gitlab" {
-  version   = "~> 3.6"
-  base_url  = "https://us-south.git.cloud.ibm.com/"
-  token     = var.gitlab_token
+provider "github" {
+  version   = "~> 4.12"
+  base_url  = "https://github.ibm.com/"
+  token     = var.github_token
 }
 
 provider "null" {
@@ -120,15 +120,15 @@ resource "null_resource" "create_kubernetes_toolchain" {
       PIPELINE_TYPE     = var.pipeline_type
       BRANCH            = var.branch
       APP_NAME          = var.app_name == "compliance-app-<timestamp>" ? "compliance-app-${formatdate("YYYYMMDDhhmm", timestamp())}" : var.app_name
-      ISSUES_REPO       = var.issues_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-incident-issues" ? gitlab_project.issues_repo[0].id : var.issues_repo
-      INVENTORY_REPO    = var.inventory_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-inventory" ? gitlab_project.inventory_repo[0].id : var.inventory_repo
-      EVIDENCE_REPO     = var.evidence_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-evidence-locker" ? gitlab_project.evidence_repo[0].id : var.evidence_repo
+      ISSUES_REPO       = var.issues_repo == "https://github.ibm.com/one-pipeline/compliance-incident-issues" ? github_repository.issues_repo[0].id : var.issues_repo
+      INVENTORY_REPO    = var.inventory_repo == "https://github.ibm.com/one-pipeline/compliance-inventory" ? github_repository.inventory_repo[0].id : var.inventory_repo
+      EVIDENCE_REPO     = var.evidence_repo == "https://github.ibm.com/one-pipeline/compliance-evidence-locker" ? github_repository.evidence_repo[0].id : var.evidence_repo
       COS_BUCKET_NAME   = "${element(split(":", ibm_cos_bucket.cos_bucket.crn),9)}"
       COS_URL           = var.cos_url
       SERVICE_API_KEY   = data.ibm_iam_api_key.service_api_key.apikey
       SM_NAME           = var.sm_name
       SM_SERVICE_NAME   = var.sm_service_name == "compliance-ci-secrets-manager" ? "compliance-ci-secrets-manager" : var.sm_service_name
-      GITLAB_TOKEN      = var.gitlab_token
+      GITHUB_TOKEN      = var.github_token
       TEKTON_CAT_REPO   = var.tekton_catalog_repo
     }
   } 

--- a/terraform/secure-kube/main.tf
+++ b/terraform/secure-kube/main.tf
@@ -16,43 +16,28 @@ provider "null" {
   version = "~> 3.1"
 }
 
-resource "github_repository" "issues_repo" {
-  count       = var.issues_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-incident-issues" ? 1 : 0
-  name        = "compliance-issues-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  description = "Repo for storing compliance issues"
-  visibility  = "private"
-  vulnerability_alerts  = true
-
-  template {
-    owner      = "one-pipeline"
-    repository = "compliance-incident-issues"
-  }
+resource "gitlab_project" "issues_repo" {
+  count             = var.issues_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-incident-issues" ? 1 : 0
+  name              = "compliance-issues-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  description       = "Repo for storing compliance issues"
+  visibility_level  = "private"
+  template_name     = "one-pipeline/compliance-incident-issues"
 }
 
-resource "github_repository" "inventory_repo" {
-  count       = var.inventory_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-inventory" ? 1 : 0
-  name        = "compliance-inventory-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  description = "Repo for storing compliance inventory"
-  visibility  = "private"
-  vulnerability_alerts  = true
-
-  template {
-    owner      = "one-pipeline"
-    repository = "compliance-inventory"
-  }
+resource "gitlab_project" "inventory_repo" {
+  count             = var.inventory_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-inventory" ? 1 : 0
+  name              = "compliance-inventory-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  description       = "Repo for storing compliance inventory"
+  visibility_level  = "private"
+  template_name     = "one-pipeline/compliance-inventory"
 }
 
-resource "github_repository" "evidence_repo" {
-  count       = var.evidence_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-evidence-locker" ? 1 : 0
-  name        = "compliance-evidence-${formatdate("YYYYMMDDhhmm", timestamp())}"
-  description = "Repo for storing compliance evidence"
-  visibility  = "private"
-  vulnerability_alerts  = true
-
-  template {
-    owner      = "one-pipeline"
-    repository = "compliance-evidence-locker"
-  }
+resource "gitlab_project" "evidence_repo" {
+  count             = var.evidence_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-evidence-locker" ? 1 : 0
+  name              = "compliance-evidence-${formatdate("YYYYMMDDhhmm", timestamp())}"
+  description       = "Repo for storing compliance evidence"
+  visibility_level  = "private"
+  template_name     = "one-pipeline/compliance-evidence-locker"
 }
 
 data "ibm_resource_group" "cos_group" {
@@ -119,9 +104,9 @@ resource "null_resource" "create_kubernetes_toolchain" {
       PIPELINE_TYPE     = var.pipeline_type
       BRANCH            = var.branch
       APP_NAME          = var.app_name == "compliance-app-<timestamp>" ? "compliance-app-${formatdate("YYYYMMDDhhmm", timestamp())}" : var.app_name
-      ISSUES_REPO       = var.issues_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-incident-issues" ? github_repository.issues_repo[0].id : var.issues_repo
-      INVENTORY_REPO    = var.inventory_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-inventory" ? github_repository.inventory_repo[0].id : var.inventory_repo
-      EVIDENCE_REPO     = var.evidence_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-evidence-locker" ? github_repository.evidence_repo[0].id : var.evidence_repo
+      ISSUES_REPO       = var.issues_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-incident-issues" ? gitlab_project.issues_repo[0].id : var.issues_repo
+      INVENTORY_REPO    = var.inventory_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-inventory" ? gitlab_project.inventory_repo[0].id : var.inventory_repo
+      EVIDENCE_REPO     = var.evidence_repo == "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-evidence-locker" ? gitlab_project.evidence_repo[0].id : var.evidence_repo
       COS_BUCKET_NAME   = "${element(split(":", ibm_cos_bucket.cos_bucket.crn),9)}"
       COS_URL           = var.cos_url
       SERVICE_API_KEY   = data.ibm_iam_api_key.service_api_key.apikey

--- a/terraform/secure-kube/scripts/create-toolchain.sh
+++ b/terraform/secure-kube/scripts/create-toolchain.sh
@@ -70,17 +70,19 @@ export VAULT_SECRET=$(cat private.key)
 export VAULT_SECRET=$(echo $VAULT_SECRET | jq -rR @uri)
 
 PARAMETERS="autocreate=true&apiKey=$API_KEY&onePipelineConfigRepo=$APPLICATION_REPO&configRepoEnabled=true"`
-`"&repository=$TOOLCHAIN_TEMPLATE_REPO&repository_token=$GITHUB_TOKEN&branch=$BRANCH&resourceGroupId=$RESOURCE_GROUP_ID"`
+`"&repository=$TOOLCHAIN_TEMPLATE_REPO&repository_token=$GITLAB_TOKEN&branch=$BRANCH&resourceGroupId=$RESOURCE_GROUP_ID"`
 `"&sourceRepoUrl=$APPLICATION_REPO&pipelineRepo=$PIPELINE_REPO&tektonCatalogRepo=$TEKTON_CAT_REPO"`
 `"&registryRegion=$TOOLCHAIN_REGION&registryNamespace=$REGISTRY_NAMESPACE&devRegion=$REGION"`
 `"&devResourceGroup=$RESOURCE_GROUP&devClusterName=$CLUSTER_NAME&devClusterNamespace=$CLUSTER_NAMESPACE"`
-`"&toolchainName=$TOOLCHAIN_NAME&pipeline_type=$PIPELINE_TYPE&appName=$APP_NAME&gitToken=$GITHUB_TOKEN"`
+`"&toolchainName=$TOOLCHAIN_NAME&pipeline_type=$PIPELINE_TYPE&appName=$APP_NAME&gitToken=$GITLAB_TOKEN"`
 `"&evidenceRepo=$EVIDENCE_REPO&issuesRepo=$ISSUES_REPO&inventoryRepo=$INVENTORY_REPO"`
 `"&cosBucketName=$COS_BUCKET_NAME&cosEndpoint=$COS_URL&vaultSecret=$VAULT_SECRET"`
 `"&smName=$SM_NAME&smRegion=$REGION&smResourceGroup=$RESOURCE_GROUP&smInstanceName=$SM_SERVICE_NAME"
 
 # debugging
 #echo "$PARAMETERS"
+# adding some sleep time, so hopefully the toolchain will see the recently provisioned Secrets Manager
+sleep 10
 
 RESPONSE=$(curl -i -X POST \
   -H 'Content-Type: application/x-www-form-urlencoded' \

--- a/terraform/secure-kube/scripts/create-toolchain.sh
+++ b/terraform/secure-kube/scripts/create-toolchain.sh
@@ -71,9 +71,11 @@ export VAULT_SECRET=$(echo $VAULT_SECRET | jq -rR @uri)
 export TOOLCHAIN_TEMPLATE_REPO=$(echo $TOOLCHAIN_TEMPLATE_REPO | jq -rR @uri)
 export APPLICATION_REPO=$(echo $APPLICATION_REPO | jq -rR @uri)
 
+export appName=$APP_NAME
+
 PARAMETERS="autocreate=true&apiKey=$API_KEY&onePipelineConfigRepo=$APPLICATION_REPO&configRepoEnabled=true"`
-`"&repository=$TOOLCHAIN_TEMPLATE_REPO&repository_token=$GITLAB_TOKEN&branch=$BRANCH&resourceGroupId=$RESOURCE_GROUP_ID"`
-`"&sourceRepoUrl=$APPLICATION_REPO"`
+`"&repository=$TOOLCHAIN_TEMPLATE_REPO&repository_token=$GITLAB_TOKEN&branch=$BRANCH"`
+`"&sourceRepoUrl=$APPLICATION_REPO&resourceGroupId=$RESOURCE_GROUP_ID"`
 `"&registryRegion=$TOOLCHAIN_REGION&registryNamespace=$REGISTRY_NAMESPACE&devRegion=$REGION"`
 `"&devResourceGroup=$RESOURCE_GROUP&devClusterName=$CLUSTER_NAME&devClusterNamespace=$CLUSTER_NAMESPACE"`
 `"&toolchainName=$TOOLCHAIN_NAME&pipeline_type=$PIPELINE_TYPE&appName=$APP_NAME&gitToken=$GITLAB_TOKEN"`

--- a/terraform/secure-kube/scripts/create-toolchain.sh
+++ b/terraform/secure-kube/scripts/create-toolchain.sh
@@ -66,16 +66,17 @@ EOF
 gpg --export-secret-key -a "Root User"  | base64 > private.key
 export VAULT_SECRET=$(cat private.key)
 
-# URL encode VAULT_SECRET
+# URL encode VAULT_SECRET, TOOLCHAIN_TEMPLATE_REPO, and APPLICATION_REPO
 export VAULT_SECRET=$(echo $VAULT_SECRET | jq -rR @uri)
+export TOOLCHAIN_TEMPLATE_REPO=$(echo $TOOLCHAIN_TEMPLATE_REPO | jq -rR @uri)
+export APPLICATION_REPO=$(echo $APPLICATION_REPO | jq -rR @uri)
 
 PARAMETERS="autocreate=true&apiKey=$API_KEY&onePipelineConfigRepo=$APPLICATION_REPO&configRepoEnabled=true"`
 `"&repository=$TOOLCHAIN_TEMPLATE_REPO&repository_token=$GITLAB_TOKEN&branch=$BRANCH&resourceGroupId=$RESOURCE_GROUP_ID"`
-`"&sourceRepoUrl=$APPLICATION_REPO&pipelineRepo=$PIPELINE_REPO&tektonCatalogRepo=$TEKTON_CAT_REPO"`
+`"&sourceRepoUrl=$APPLICATION_REPO"`
 `"&registryRegion=$TOOLCHAIN_REGION&registryNamespace=$REGISTRY_NAMESPACE&devRegion=$REGION"`
 `"&devResourceGroup=$RESOURCE_GROUP&devClusterName=$CLUSTER_NAME&devClusterNamespace=$CLUSTER_NAMESPACE"`
 `"&toolchainName=$TOOLCHAIN_NAME&pipeline_type=$PIPELINE_TYPE&appName=$APP_NAME&gitToken=$GITLAB_TOKEN"`
-`"&evidenceRepo=$EVIDENCE_REPO&issuesRepo=$ISSUES_REPO&inventoryRepo=$INVENTORY_REPO"`
 `"&cosBucketName=$COS_BUCKET_NAME&cosEndpoint=$COS_URL&vaultSecret=$VAULT_SECRET"`
 `"&smName=$SM_NAME&smRegion=$REGION&smResourceGroup=$RESOURCE_GROUP&smInstanceName=$SM_SERVICE_NAME"
 

--- a/terraform/secure-kube/scripts/create-toolchain.sh
+++ b/terraform/secure-kube/scripts/create-toolchain.sh
@@ -75,7 +75,7 @@ PARAMETERS="autocreate=true&apiKey=$API_KEY&onePipelineConfigRepo=$APPLICATION_R
 `"&sourceRepoUrl=$APPLICATION_REPO&pipelineRepo=$PIPELINE_REPO&tektonCatalogRepo=$TEKTON_CAT_REPO"`
 `"&registryRegion=$TOOLCHAIN_REGION&registryNamespace=$REGISTRY_NAMESPACE&devRegion=$REGION"`
 `"&devResourceGroup=$RESOURCE_GROUP&devClusterName=$CLUSTER_NAME&devClusterNamespace=$CLUSTER_NAMESPACE"`
-`"&toolchainName=$TOOLCHAIN_NAME&pipeline_type=$PIPELINE_TYPE&appName=$APP_NAME&gitToken=$GITLAB_TOKEN"`
+`"&toolchainName=$TOOLCHAIN_NAME&pipeline_type=$PIPELINE_TYPE&appName=$APP_NAME&gitToken=$GITHUB_TOKEN"`
 `"&evidenceRepo=$EVIDENCE_REPO&issuesRepo=$ISSUES_REPO&inventoryRepo=$INVENTORY_REPO"`
 `"&cosBucketName=$COS_BUCKET_NAME&cosEndpoint=$COS_URL&vaultSecret=$VAULT_SECRET"`
 `"&smName=$SM_NAME&smRegion=$REGION&smResourceGroup=$RESOURCE_GROUP&smInstanceName=$SM_SERVICE_NAME"

--- a/terraform/secure-kube/scripts/create-toolchain.sh
+++ b/terraform/secure-kube/scripts/create-toolchain.sh
@@ -25,31 +25,31 @@ if [[ $SM_SERVICE_NAME == "compliance-ci-secrets-manager" ]]; then
   echo "Creating Secrets Manager service..."
   # NOTE: Secrets Manager service can take approx 5-8 minutes to provision
   ibmcloud resource service-instance-create $SM_SERVICE_NAME secrets-manager lite us-south
-  #echo "Waiting up to 8 minutes for Secrets Manager service to provision..."
-  #wait=480
-  #count=0
-  #sleep_time=60
-  #while [[ $count -le $wait ]]; do
-    #ibmcloud resource service-instances >services.txt
-    #secretLine=$(cat services.txt | grep $SM_SERVICE_NAME)
-    #stringArray=($secretLine)
-    #if [[ "${stringArray[2]}" != "active" ]]; then
-      #echo "Secrets Manager status: ${stringArray[2]}"
-      #count=$(($count + $sleep_time))
-      #if [[ $count -gt $wait ]]; then
-        #echo "Secrets Manager took longer than 8 minutes to provision"
-        #echo "Something must have gone wrong. Exiting."
-        #exit 1
-      #else
-        #echo "Waiting $sleep_time seconds to check again..."
-        #sleep $sleep_time
-      #fi
-    #else
-      #echo "Secrets Manager successfully provisioned"
-      #echo "Status: ${stringArray[2]}"
-      #break
-    #fi
-  #done
+  echo "Waiting up to 8 minutes for Secrets Manager service to provision..."
+  wait=480
+  count=0
+  sleep_time=60
+  while [[ $count -le $wait ]]; do
+    ibmcloud resource service-instances >services.txt
+    secretLine=$(cat services.txt | grep $SM_SERVICE_NAME)
+    stringArray=($secretLine)
+    if [[ "${stringArray[2]}" != "active" ]]; then
+      echo "Secrets Manager status: ${stringArray[2]}"
+      count=$(($count + $sleep_time))
+      if [[ $count -gt $wait ]]; then
+        echo "Secrets Manager took longer than 8 minutes to provision"
+        echo "Something must have gone wrong. Exiting."
+        exit 1
+      else
+        echo "Waiting $sleep_time seconds to check again..."
+        sleep $sleep_time
+      fi
+    else
+      echo "Secrets Manager successfully provisioned"
+      echo "Status: ${stringArray[2]}"
+      break
+    fi
+  done
 fi
 
 # generate gpg key

--- a/terraform/secure-kube/scripts/create-toolchain.sh
+++ b/terraform/secure-kube/scripts/create-toolchain.sh
@@ -25,21 +25,21 @@ if [[ $SM_SERVICE_NAME == "compliance-ci-secrets-manager" ]]; then
   echo "Creating Secrets Manager service..."
   # NOTE: Secrets Manager service can take approx 5-8 minutes to provision
   ibmcloud resource service-instance-create $SM_SERVICE_NAME secrets-manager lite us-south
-  echo "Waiting up to 8 minutes for Secrets Manager service to provision..."
-  wait=480
+  wait_secs=600
   count=0
   sleep_time=60
-  while [[ $count -le $wait ]]; do
+  wait_mins=$(($wait_secs / $sleep_time))
+  echo "Waiting up to $wait_mins minutes for Secrets Manager service to provision..."
+  while [[ $count -le $wait_secs ]]; do
     ibmcloud resource service-instances >services.txt
     secretLine=$(cat services.txt | grep $SM_SERVICE_NAME)
     stringArray=($secretLine)
     if [[ "${stringArray[2]}" != "active" ]]; then
       echo "Secrets Manager status: ${stringArray[2]}"
       count=$(($count + $sleep_time))
-      if [[ $count -gt $wait ]]; then
-        echo "Secrets Manager took longer than 8 minutes to provision"
-        echo "Something must have gone wrong. Exiting."
-        exit 1
+      if [[ $count -gt $wait_secs ]]; then
+        echo "Secrets Manager service took longer than $wait_mins minutes to provision."
+        echo "You might have to re-configure this integration in the toolchain once the service finally provisions."
       else
         echo "Waiting $sleep_time seconds to check again..."
         sleep $sleep_time

--- a/terraform/secure-kube/scripts/create-toolchain.sh
+++ b/terraform/secure-kube/scripts/create-toolchain.sh
@@ -71,6 +71,7 @@ export VAULT_SECRET=$(cat private.key)
 export VAULT_SECRET=$(echo $VAULT_SECRET | jq -rR @uri)
 
 PARAMETERS="autocreate=true&apiKey=$API_KEY&onePipelineConfigRepo=$APPLICATION_REPO&configRepoEnabled=true"`
+`"&repository=$TOOLCHAIN_TEMPLATE_REPO&branch=$BRANCH"`
 `"&sourceRepoUrl=$APPLICATION_REPO&pipelineRepo=$PIPELINE_REPO&tektonCatalogRepo=$TEKTON_CAT_REPO"`
 `"&registryRegion=$TOOLCHAIN_REGION&registryNamespace=$REGISTRY_NAMESPACE&devRegion=$REGION"`
 `"&devResourceGroup=$RESOURCE_GROUP&devClusterName=$CLUSTER_NAME&devClusterNamespace=$CLUSTER_NAMESPACE"`

--- a/terraform/secure-kube/scripts/create-toolchain.sh
+++ b/terraform/secure-kube/scripts/create-toolchain.sh
@@ -75,7 +75,7 @@ PARAMETERS="autocreate=true&apiKey=$API_KEY&onePipelineConfigRepo=$APPLICATION_R
 `"&sourceRepoUrl=$APPLICATION_REPO&pipelineRepo=$PIPELINE_REPO&tektonCatalogRepo=$TEKTON_CAT_REPO"`
 `"&registryRegion=$TOOLCHAIN_REGION&registryNamespace=$REGISTRY_NAMESPACE&devRegion=$REGION"`
 `"&devResourceGroup=$RESOURCE_GROUP&devClusterName=$CLUSTER_NAME&devClusterNamespace=$CLUSTER_NAMESPACE"`
-`"&toolchainName=$TOOLCHAIN_NAME&pipeline_type=$PIPELINE_TYPE&appName=$APP_NAME&gitToken=$GITHUB_TOKEN"`
+`"&toolchainName=$TOOLCHAIN_NAME&pipeline_type=$PIPELINE_TYPE&appName=$APP_NAME&gitToken=$GITLAB_TOKEN"`
 `"&evidenceRepo=$EVIDENCE_REPO&issuesRepo=$ISSUES_REPO&inventoryRepo=$INVENTORY_REPO"`
 `"&cosBucketName=$COS_BUCKET_NAME&cosEndpoint=$COS_URL&vaultSecret=$VAULT_SECRET"`
 `"&smName=$SM_NAME&smRegion=$REGION&smResourceGroup=$RESOURCE_GROUP&smInstanceName=$SM_SERVICE_NAME"

--- a/terraform/secure-kube/scripts/create-toolchain.sh
+++ b/terraform/secure-kube/scripts/create-toolchain.sh
@@ -3,8 +3,7 @@
 #// https://github.com/open-toolchain/sdk/wiki/Toolchain-Creation-page-parameters#headless-toolchain-creation-and-update
 
 # log in using the api key
-ibmcloud login --apikey "$API_KEY" -r "$REGION" 
-ibmcloud target -g $RESOURCE_GROUP
+ibmcloud login --apikey "$API_KEY" -r "$REGION"
 
 # target default resource group for now
 ibmcloud target -g $RESOURCE_GROUP 
@@ -20,7 +19,7 @@ if [[ ! $TOOLCHAIN_REGION =~ "ibm:" ]]; then
   export TOOLCHAIN_REGION="ibm:yp:$REGION"
 fi
 
-#RESOURCE_GROUP_ID=$(ibmcloud resource group $RESOURCE_GROUP --output JSON | jq ".[].id" -r)
+RESOURCE_GROUP_ID=$(ibmcloud resource group $RESOURCE_GROUP --output JSON | jq ".[].id" -r)
 
 if [[ $SM_SERVICE_NAME == "compliance-ci-secrets-manager" ]]; then
   echo "Creating Secrets Manager service..."
@@ -71,7 +70,7 @@ export VAULT_SECRET=$(cat private.key)
 export VAULT_SECRET=$(echo $VAULT_SECRET | jq -rR @uri)
 
 PARAMETERS="autocreate=true&apiKey=$API_KEY&onePipelineConfigRepo=$APPLICATION_REPO&configRepoEnabled=true"`
-`"&repository=$TOOLCHAIN_TEMPLATE_REPO&branch=$BRANCH"`
+`"&repository=$TOOLCHAIN_TEMPLATE_REPO&branch=$BRANCH&resourceGroupId=$RESOURCE_GROUP_ID"`
 `"&sourceRepoUrl=$APPLICATION_REPO&pipelineRepo=$PIPELINE_REPO&tektonCatalogRepo=$TEKTON_CAT_REPO"`
 `"&registryRegion=$TOOLCHAIN_REGION&registryNamespace=$REGISTRY_NAMESPACE&devRegion=$REGION"`
 `"&devResourceGroup=$RESOURCE_GROUP&devClusterName=$CLUSTER_NAME&devClusterNamespace=$CLUSTER_NAMESPACE"`

--- a/terraform/secure-kube/scripts/create-toolchain.sh
+++ b/terraform/secure-kube/scripts/create-toolchain.sh
@@ -70,7 +70,7 @@ export VAULT_SECRET=$(cat private.key)
 export VAULT_SECRET=$(echo $VAULT_SECRET | jq -rR @uri)
 
 PARAMETERS="autocreate=true&apiKey=$API_KEY&onePipelineConfigRepo=$APPLICATION_REPO&configRepoEnabled=true"`
-`"&repository=$TOOLCHAIN_TEMPLATE_REPO&branch=$BRANCH&resourceGroupId=$RESOURCE_GROUP_ID"`
+`"&repository=$TOOLCHAIN_TEMPLATE_REPO&repository_token=$GITHUB_TOKEN&branch=$BRANCH&resourceGroupId=$RESOURCE_GROUP_ID"`
 `"&sourceRepoUrl=$APPLICATION_REPO&pipelineRepo=$PIPELINE_REPO&tektonCatalogRepo=$TEKTON_CAT_REPO"`
 `"&registryRegion=$TOOLCHAIN_REGION&registryNamespace=$REGISTRY_NAMESPACE&devRegion=$REGION"`
 `"&devResourceGroup=$RESOURCE_GROUP&devClusterName=$CLUSTER_NAME&devClusterNamespace=$CLUSTER_NAMESPACE"`

--- a/terraform/secure-kube/variables.tf
+++ b/terraform/secure-kube/variables.tf
@@ -125,9 +125,9 @@ variable "storage" {
   default     = "standard"
 }
 
-variable "gitlab_token" {
+variable "github_token" {
   type        = string
-  description = "A GitLab Personal Access Token (https://us-south.git.cloud.ibm.com/-/profile/personal_access_tokens)"
+  description = "A GitHub OAuth/Personal Access Token (https://github.ibm.com/settings/tokens)"
 }
 
 variable "ibmcloud_api_key" {

--- a/terraform/secure-kube/variables.tf
+++ b/terraform/secure-kube/variables.tf
@@ -6,7 +6,7 @@ variable "toolchain_name" {
 
 variable "application_repo" {
   type        = string
-  description = "Hello compliance app repo"
+  description = "Your application repository. The default URL is a sample application."
   default     = "https://us-south.git.cloud.ibm.com/open-toolchain/hello-compliance-app"
 }
 
@@ -57,7 +57,7 @@ variable "resource_group" {
 
 variable "cluster_name" {
   type        = string
-  description = "Name of new Kubernetes Cluster to deploy application into. WARNING: On first run, the plan will fail to apply if the named cluster already exists. On second run, the plan will destroy the previously created cluster and create a new one (no matter if the name changes)."
+  description = "Name of Kubernetes Cluster where application will be deployed. If the default value is not overridden, a new cluster will be provisioned."
   default     = "compliance-cluster"
 }
 
@@ -65,6 +65,43 @@ variable "cluster_namespace" {
   type        = string
   description = "Kubernetes namespace to deploy into"
   default     = "default"
+}
+
+variable "datacenter" {
+  type        = string
+  description = "Zone from `ibmcloud ks zones --provider classic`"
+  default     = "dal12"
+}
+
+variable "default_pool_size" {
+  default     = "1"
+  description = "Number of worker nodes for the new Kubernetes cluster"
+}
+
+variable "machine_type" {
+  default     = "b3c.4x16"
+  description = "Name of machine type from `ibmcloud ks flavors --zone <ZONE>`"
+}
+variable "hardware" {
+  default     = "shared"
+  description = "The level of hardware isolation for your worker node. Use 'dedicated' to have available physical resources dedicated to you only, or 'shared' to allow physical resources to be shared with other IBM customers. For IBM Cloud Public accounts, the default value is shared. For IBM Cloud Dedicated accounts, dedicated is the only available option."
+}
+
+variable "kube_version" {
+  default     = "1.20.7"
+  description = "Version of Kubernetes to apply to the new Kubernetes cluster"
+}
+
+variable "public_vlan_num" {
+  type        = string
+  description = "Number for public VLAN from `ibmcloud ks vlans --zone <ZONE>`"
+  default     = "1911479"
+}
+
+variable "private_vlan_num" {
+  type        = string
+  description = "Number for private VLAN from `ibmcloud ks vlans --zone <ZONE>`"
+  default     = "1891999"
 }
 
 variable "toolchain_template_repo" {
@@ -95,12 +132,12 @@ variable "storage" {
   default     = "standard"
 }
 
-variable "gitlab_token" {
-  type        = string
-  description = "A GitLab Personal Access Token (https://us-south.git.cloud.ibm.com/-/profile/personal_access_tokens)"
-}
-
 variable "ibmcloud_api_key" {
   type        = string
   description = "The IAM API Key for IBM Cloud access (https://cloud.ibm.com/iam/apikeys)"
+}
+
+variable "gitlab_token" {
+  type        = string
+  description = "A GitLab Personal Access Token (https://us-south.git.cloud.ibm.com/-/profile/personal_access_tokens)"
 }

--- a/terraform/secure-kube/variables.tf
+++ b/terraform/secure-kube/variables.tf
@@ -7,19 +7,19 @@ variable "toolchain_name" {
 variable "application_repo" {
   type        = string
   description = "Hello compliance app repo"
-  default     = "https://github.ibm.com/open-toolchain/hello-compliance-app"
+  default     = "https://us-south.git.cloud.ibm.com/open-toolchain/hello-compliance-app"
 }
 
 variable "inventory_repo" {
   type        = string
   description = "Repo where compliance inventory will be stored. If no override is provided, then the default repo will be cloned."
-  default     = "https://github.ibm.com/one-pipeline/compliance-inventory"
+  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-inventory"
 }
 
 variable "issues_repo" {
   type        = string
   description = "Repo where compliance issues will be stored. If no override is provided, then the default repo will be cloned."
-  default     = "https://github.ibm.com/one-pipeline/compliance-incident-issues"
+  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-incident-issues"
 }
 
 variable "sm_name" {
@@ -35,7 +35,7 @@ variable "sm_service_name" {
 variable "evidence_repo" {
   type        = string
   description = "Repo where compliance evidence will be stored. If no override is provided, then the default repo will be cloned."
-  default     = "https://github.ibm.com/one-pipeline/compliance-evidence-locker"
+  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-evidence-locker"
 }
 
 variable "cos_url" {
@@ -52,13 +52,13 @@ variable "bucket_name" {
 variable "pipeline_repo" {
   type        = string
   description = "Repo where Tekton resources are defined. WARNING: Do not alter the code in this repository unless absolutely necessary."
-  default     = "https://github.ibm.com/one-pipeline/compliance-pipelines"
+  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-pipelines"
 }
 
 variable "tekton_catalog_repo" {
   type        = string
   description = "Repo where common Tekton task resources are defined. WARNING: Do not alter the code in this repository unless absolutely necessary."
-  default     = "https://github.ibm.com/one-pipeline/common-tekton-tasks"
+  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/common-tekton-tasks"
 }
 
 variable "app_name" {
@@ -100,7 +100,7 @@ variable "cluster_namespace" {
 variable "toolchain_template_repo" {
   type        = string
   description = "Compliance CI toolchain template repo"
-  default     = "https://github.ibm.com/open-toolchain/compliance-ci-toolchain"
+  default     = "https://us-south.git.cloud.ibm.com/open-toolchain/compliance-ci-toolchain"
 }
 
 variable "branch" {
@@ -125,9 +125,9 @@ variable "storage" {
   default     = "standard"
 }
 
-variable "github_token" {
+variable "gitlab_token" {
   type        = string
-  description = "A GitHub OAuth/Personal Access Token (https://github.ibm.com/settings/tokens)"
+  description = "A GitLab Personal Access Token (https://us-south.git.cloud.ibm.com/-/profile/personal_access_tokens)"
 }
 
 variable "ibmcloud_api_key" {

--- a/terraform/secure-kube/variables.tf
+++ b/terraform/secure-kube/variables.tf
@@ -125,9 +125,9 @@ variable "storage" {
   default     = "standard"
 }
 
-variable "github_token" {
+variable "gitlab_token" {
   type        = string
-  description = "A GitHub OAuth/Personal Access Token (https://github.ibm.com/settings/tokens)"
+  description = "A GitLab Personal Access Token (https://us-south.git.cloud.ibm.com/-/profile/personal_access_tokens)"
 }
 
 variable "ibmcloud_api_key" {

--- a/terraform/secure-kube/variables.tf
+++ b/terraform/secure-kube/variables.tf
@@ -10,18 +10,6 @@ variable "application_repo" {
   default     = "https://us-south.git.cloud.ibm.com/open-toolchain/hello-compliance-app"
 }
 
-variable "inventory_repo" {
-  type        = string
-  description = "Repo where compliance inventory will be stored. If no override is provided, then the default repo will be cloned."
-  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-inventory"
-}
-
-variable "issues_repo" {
-  type        = string
-  description = "Repo where compliance issues will be stored. If no override is provided, then the default repo will be cloned."
-  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-incident-issues"
-}
-
 variable "sm_name" {
   description = "Name of the Secrets Manager tool integration (Ex. my-secrets-manager)"
   default     = "sm-compliance-secrets"
@@ -30,12 +18,6 @@ variable "sm_name" {
 variable "sm_service_name" {
   description = "Name of the Secrets Manager service. NOTE: Only 1 Secrets Manager instance is allowed. If you already have a Secrets Manager service provisioned, please override this value to its name."
   default     = "compliance-ci-secrets-manager"
-}
-
-variable "evidence_repo" {
-  type        = string
-  description = "Repo where compliance evidence will be stored. If no override is provided, then the default repo will be cloned."
-  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-evidence-locker"
 }
 
 variable "cos_url" {
@@ -47,18 +29,6 @@ variable "cos_url" {
 variable "bucket_name" {
   description = "Name of the Cloud Object Storage bucket. NOTE: The <timestamp> will be in the format YYYYMMDDhhmm."
   default     = "cos-compliance-bucket-<timestamp>"
-}
-
-variable "pipeline_repo" {
-  type        = string
-  description = "Repo where Tekton resources are defined. WARNING: Do not alter the code in this repository unless absolutely necessary."
-  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-pipelines"
-}
-
-variable "tekton_catalog_repo" {
-  type        = string
-  description = "Repo where common Tekton task resources are defined. WARNING: Do not alter the code in this repository unless absolutely necessary."
-  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/common-tekton-tasks"
 }
 
 variable "app_name" {

--- a/terraform/secure-kube/variables.tf
+++ b/terraform/secure-kube/variables.tf
@@ -87,7 +87,7 @@ variable "resource_group" {
 
 variable "cluster_name" {
   type        = string
-  description = "Name of new Kubernetes Cluster to deploy application into. NOTE: Cluster must not already exist."
+  description = "Name of new Kubernetes Cluster to deploy application into. WARNING: On first run, the plan will fail to apply if the named cluster already exists. On second run, the plan will destroy the previously created cluster and create a new one (no matter if the name changes)."
   default     = "compliance-cluster"
 }
 

--- a/terraform/secure-kube/variables.tf
+++ b/terraform/secure-kube/variables.tf
@@ -97,43 +97,6 @@ variable "cluster_namespace" {
   default     = "default"
 }
 
-variable "datacenter" {
-  type        = string
-  description = "Zone from `ibmcloud ks zones --provider classic`"
-  default     = "dal12"
-}
-
-variable "default_pool_size" {
-  default     = "1"
-  description = "Number of worker nodes for the new Kubernetes cluster"
-}
-
-variable "machine_type" {
-  default     = "b3c.4x16"
-  description = "Name of machine type from `ibmcloud ks flavors --zone <ZONE>`"
-}
-variable "hardware" {
-  default     = "shared"
-  description = "The level of hardware isolation for your worker node. Use 'dedicated' to have available physical resources dedicated to you only, or 'shared' to allow physical resources to be shared with other IBM customers. For IBM Cloud Public accounts, the default value is shared. For IBM Cloud Dedicated accounts, dedicated is the only available option."
-}
-
-variable "kube_version" {
-  default     = "1.20.7"
-  description = "Version of Kubernetes to apply to the new Kubernetes cluster"
-}
-
-variable "public_vlan_num" {
-  type        = string
-  description = "Number for public VLAN from `ibmcloud ks vlans --zone <ZONE>`"
-  default     = "1911479"
-}
-
-variable "private_vlan_num" {
-  type        = string
-  description = "Number for private VLAN from `ibmcloud ks vlans --zone <ZONE>`"
-  default     = "1891999"
-}
-
 variable "toolchain_template_repo" {
   type        = string
   description = "Compliance CI toolchain template repo"

--- a/terraform/secure-kube/variables.tf
+++ b/terraform/secure-kube/variables.tf
@@ -7,19 +7,19 @@ variable "toolchain_name" {
 variable "application_repo" {
   type        = string
   description = "Hello compliance app repo"
-  default     = "https://github.ibm.com/open-toolchain/hello-compliance-app"
+  default     = "https://us-south.git.cloud.ibm.com/open-toolchain/hello-compliance-app"
 }
 
 variable "inventory_repo" {
   type        = string
   description = "Repo where compliance inventory will be stored. If no override is provided, then the default repo will be cloned."
-  default     = "https://github.ibm.com/one-pipeline/compliance-inventory"
+  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-inventory"
 }
 
 variable "issues_repo" {
   type        = string
   description = "Repo where compliance issues will be stored. If no override is provided, then the default repo will be cloned."
-  default     = "https://github.ibm.com/one-pipeline/compliance-incident-issues"
+  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-incident-issues"
 }
 
 variable "sm_name" {
@@ -35,7 +35,7 @@ variable "sm_service_name" {
 variable "evidence_repo" {
   type        = string
   description = "Repo where compliance evidence will be stored. If no override is provided, then the default repo will be cloned."
-  default     = "https://github.ibm.com/one-pipeline/compliance-evidence-locker"
+  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-evidence-locker"
 }
 
 variable "cos_url" {
@@ -52,13 +52,13 @@ variable "bucket_name" {
 variable "pipeline_repo" {
   type        = string
   description = "Repo where Tekton resources are defined. WARNING: Do not alter the code in this repository unless absolutely necessary."
-  default     = "https://github.ibm.com/one-pipeline/compliance-pipelines"
+  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-pipelines"
 }
 
 variable "tekton_catalog_repo" {
   type        = string
   description = "Repo where common Tekton task resources are defined. WARNING: Do not alter the code in this repository unless absolutely necessary."
-  default     = "https://github.ibm.com/one-pipeline/common-tekton-tasks"
+  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/common-tekton-tasks"
 }
 
 variable "app_name" {
@@ -100,7 +100,7 @@ variable "cluster_namespace" {
 variable "toolchain_template_repo" {
   type        = string
   description = "Compliance CI toolchain template repo"
-  default     = "https://github.ibm.com/open-toolchain/compliance-ci-toolchain"
+  default     = "https://us-south.git.cloud.ibm.com/open-toolchain/compliance-ci-toolchain"
 }
 
 variable "branch" {

--- a/terraform/secure-kube/variables.tf
+++ b/terraform/secure-kube/variables.tf
@@ -7,19 +7,19 @@ variable "toolchain_name" {
 variable "application_repo" {
   type        = string
   description = "Hello compliance app repo"
-  default     = "https://us-south.git.cloud.ibm.com/open-toolchain/hello-compliance-app"
+  default     = "https://github.ibm.com/open-toolchain/hello-compliance-app"
 }
 
 variable "inventory_repo" {
   type        = string
   description = "Repo where compliance inventory will be stored. If no override is provided, then the default repo will be cloned."
-  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-inventory"
+  default     = "https://github.ibm.com/one-pipeline/compliance-inventory"
 }
 
 variable "issues_repo" {
   type        = string
   description = "Repo where compliance issues will be stored. If no override is provided, then the default repo will be cloned."
-  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-incident-issues"
+  default     = "https://github.ibm.com/one-pipeline/compliance-incident-issues"
 }
 
 variable "sm_name" {
@@ -35,7 +35,7 @@ variable "sm_service_name" {
 variable "evidence_repo" {
   type        = string
   description = "Repo where compliance evidence will be stored. If no override is provided, then the default repo will be cloned."
-  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-evidence-locker"
+  default     = "https://github.ibm.com/one-pipeline/compliance-evidence-locker"
 }
 
 variable "cos_url" {
@@ -52,13 +52,13 @@ variable "bucket_name" {
 variable "pipeline_repo" {
   type        = string
   description = "Repo where Tekton resources are defined. WARNING: Do not alter the code in this repository unless absolutely necessary."
-  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/compliance-pipelines"
+  default     = "https://github.ibm.com/one-pipeline/compliance-pipelines"
 }
 
 variable "tekton_catalog_repo" {
   type        = string
   description = "Repo where common Tekton task resources are defined. WARNING: Do not alter the code in this repository unless absolutely necessary."
-  default     = "https://us-south.git.cloud.ibm.com/one-pipeline/common-tekton-tasks"
+  default     = "https://github.ibm.com/one-pipeline/common-tekton-tasks"
 }
 
 variable "app_name" {
@@ -100,7 +100,7 @@ variable "cluster_namespace" {
 variable "toolchain_template_repo" {
   type        = string
   description = "Compliance CI toolchain template repo"
-  default     = "https://us-south.git.cloud.ibm.com/open-toolchain/compliance-ci-toolchain"
+  default     = "https://github.ibm.com/open-toolchain/compliance-ci-toolchain"
 }
 
 variable "branch" {

--- a/terraform/secure-openshift/scripts/create-toolchain.sh
+++ b/terraform/secure-openshift/scripts/create-toolchain.sh
@@ -3,8 +3,10 @@
 #// https://github.com/open-toolchain/sdk/wiki/Toolchain-Creation-page-parameters#headless-toolchain-creation-and-update
 
 # log in using the api key
-ibmcloud login --apikey "$API_KEY" -r "$REGION" 
-ibmcloud target -g $RESOURCE_GROUP
+ibmcloud login --apikey "$API_KEY" -r "$REGION"
+
+# target default resource group for now
+ibmcloud target -g $RESOURCE_GROUP 
 
 # get the bearer token to create the toolchain instance
 IAM_TOKEN="IAM token:  "
@@ -17,37 +19,37 @@ if [[ ! $TOOLCHAIN_REGION =~ "ibm:" ]]; then
   export TOOLCHAIN_REGION="ibm:yp:$REGION"
 fi
 
-#RESOURCE_GROUP_ID=$(ibmcloud resource group $RESOURCE_GROUP --output JSON | jq ".[].id" -r)
+RESOURCE_GROUP_ID=$(ibmcloud resource group $RESOURCE_GROUP --output JSON | jq ".[].id" -r)
 
 if [[ $SM_SERVICE_NAME == "compliance-ci-secrets-manager" ]]; then
   echo "Creating Secrets Manager service..."
   # NOTE: Secrets Manager service can take approx 5-8 minutes to provision
   ibmcloud resource service-instance-create $SM_SERVICE_NAME secrets-manager lite us-south
-  #echo "Waiting up to 8 minutes for Secrets Manager service to provision..."
-  #wait=480
-  #count=0
-  #sleep_time=60
-  #while [[ $count -le $wait ]]; do
-    #ibmcloud resource service-instances >services.txt
-    #secretLine=$(cat services.txt | grep $SM_SERVICE_NAME)
-    #stringArray=($secretLine)
-    #if [[ "${stringArray[2]}" != "active" ]]; then
-      #echo "Secrets Manager status: ${stringArray[2]}"
-      #count=$(($count + $sleep_time))
-      #if [[ $count -gt $wait ]]; then
-        #echo "Secrets Manager took longer than 8 minutes to provision"
-        #echo "Something must have gone wrong. Exiting."
-        #exit 1
-      #else
-        #echo "Waiting $sleep_time seconds to check again..."
-        #sleep $sleep_time
-      #fi
-    #else
-      #echo "Secrets Manager successfully provisioned"
-      #echo "Status: ${stringArray[2]}"
-      #break
-    #fi
-  #done
+  wait_secs=600
+  count=0
+  sleep_time=60
+  wait_mins=$(($wait_secs / $sleep_time))
+  echo "Waiting up to $wait_mins minutes for Secrets Manager service to provision..."
+  while [[ $count -le $wait_secs ]]; do
+    ibmcloud resource service-instances >services.txt
+    secretLine=$(cat services.txt | grep $SM_SERVICE_NAME)
+    stringArray=($secretLine)
+    if [[ "${stringArray[2]}" != "active" ]]; then
+      echo "Secrets Manager status: ${stringArray[2]}"
+      count=$(($count + $sleep_time))
+      if [[ $count -gt $wait_secs ]]; then
+        echo "Secrets Manager service took longer than $wait_mins minutes to provision."
+        echo "You might have to re-configure this integration in the toolchain once the service finally provisions."
+      else
+        echo "Waiting $sleep_time seconds to check again..."
+        sleep $sleep_time
+      fi
+    else
+      echo "Secrets Manager successfully provisioned"
+      echo "Status: ${stringArray[2]}"
+      break
+    fi
+  done
 fi
 
 # generate gpg key
@@ -64,20 +66,26 @@ EOF
 gpg --export-secret-key -a "Root User"  | base64 > private.key
 export VAULT_SECRET=$(cat private.key)
 
-# URL encode VAULT_SECRET
+# URL encode VAULT_SECRET, TOOLCHAIN_TEMPLATE_REPO, and APPLICATION_REPO
 export VAULT_SECRET=$(echo $VAULT_SECRET | jq -rR @uri)
+export TOOLCHAIN_TEMPLATE_REPO=$(echo $TOOLCHAIN_TEMPLATE_REPO | jq -rR @uri)
+export APPLICATION_REPO=$(echo $APPLICATION_REPO | jq -rR @uri)
+
+export appName=$APP_NAME
 
 PARAMETERS="autocreate=true&apiKey=$API_KEY&onePipelineConfigRepo=$APPLICATION_REPO&configRepoEnabled=true"`
-`"&sourceRepoUrl=$APPLICATION_REPO&pipelineRepo=$PIPELINE_REPO&tektonCatalogRepo=$TEKTON_CAT_REPO"`
+`"&repository=$TOOLCHAIN_TEMPLATE_REPO&repository_token=$GITLAB_TOKEN&branch=$BRANCH"`
+`"&sourceRepoUrl=$APPLICATION_REPO&resourceGroupId=$RESOURCE_GROUP_ID"`
 `"&registryRegion=$TOOLCHAIN_REGION&registryNamespace=$REGISTRY_NAMESPACE&devRegion=$REGION"`
 `"&devResourceGroup=$RESOURCE_GROUP&devClusterName=$CLUSTER_NAME&devClusterNamespace=$CLUSTER_NAMESPACE"`
-`"&toolchainName=$TOOLCHAIN_NAME&pipeline_type=$PIPELINE_TYPE&appName=$APP_NAME&gitToken=$GITHUB_TOKEN"`
-`"&evidenceRepo=$EVIDENCE_REPO&issuesRepo=$ISSUES_REPO&inventoryRepo=$INVENTORY_REPO"`
+`"&toolchainName=$TOOLCHAIN_NAME&pipeline_type=$PIPELINE_TYPE&appName=$APP_NAME&gitToken=$GITLAB_TOKEN"`
 `"&cosBucketName=$COS_BUCKET_NAME&cosEndpoint=$COS_URL&vaultSecret=$VAULT_SECRET"`
 `"&smName=$SM_NAME&smRegion=$REGION&smResourceGroup=$RESOURCE_GROUP&smInstanceName=$SM_SERVICE_NAME"
 
 # debugging
 #echo "$PARAMETERS"
+# adding some sleep time, so hopefully the toolchain will see the recently provisioned Secrets Manager
+sleep 10
 
 RESPONSE=$(curl -i -X POST \
   -H 'Content-Type: application/x-www-form-urlencoded' \

--- a/terraform/secure-openshift/variables.tf
+++ b/terraform/secure-openshift/variables.tf
@@ -6,20 +6,8 @@ variable "toolchain_name" {
 
 variable "application_repo" {
   type        = string
-  description = "Hello compliance app repo"
-  default     = "https://github.ibm.com/open-toolchain/hello-compliance-app"
-}
-
-variable "inventory_repo" {
-  type        = string
-  description = "Repo where compliance inventory will be stored. If no override is provided, then the default repo will be cloned."
-  default     = "https://github.ibm.com/one-pipeline/compliance-inventory"
-}
-
-variable "issues_repo" {
-  type        = string
-  description = "Repo where compliance issues will be stored. If no override is provided, then the default repo will be cloned."
-  default     = "https://github.ibm.com/one-pipeline/compliance-incident-issues"
+  description = "Your application repository. The default URL is a sample application."
+  default     = "https://us-south.git.cloud.ibm.com/open-toolchain/hello-compliance-app"
 }
 
 variable "sm_name" {
@@ -32,12 +20,6 @@ variable "sm_service_name" {
   default     = "compliance-ci-secrets-manager"
 }
 
-variable "evidence_repo" {
-  type        = string
-  description = "Repo where compliance evidence will be stored. If no override is provided, then the default repo will be cloned."
-  default     = "https://github.ibm.com/one-pipeline/compliance-evidence-locker"
-}
-
 variable "cos_url" {
   type        = string
   description = "URL endpoint to Cloud Object Storage Bucket"
@@ -47,18 +29,6 @@ variable "cos_url" {
 variable "bucket_name" {
   description = "Name of the Cloud Object Storage bucket. NOTE: The <timestamp> will be in the format YYYYMMDDhhmm."
   default     = "cos-compliance-bucket-<timestamp>"
-}
-
-variable "pipeline_repo" {
-  type        = string
-  description = "Repo where Tekton resources are defined. WARNING: Do not alter the code in this repository unless absolutely necessary."
-  default     = "https://github.ibm.com/one-pipeline/compliance-pipelines"
-}
-
-variable "tekton_catalog_repo" {
-  type        = string
-  description = "Repo where common Tekton task resources are defined. WARNING: Do not alter the code in this repository unless absolutely necessary."
-  default     = "https://github.ibm.com/one-pipeline/common-tekton-tasks"
 }
 
 variable "app_name" {
@@ -87,7 +57,7 @@ variable "resource_group" {
 
 variable "cluster_name" {
   type        = string
-  description = "Name of new Kubernetes Cluster to deploy application into. NOTE: Cluster must not already exist."
+  description = "Name of Kubernetes Cluster where application will be deployed. If the default value is not overridden, a new cluster will be provisioned."
   default     = "compliance-cluster"
 }
 
@@ -137,7 +107,7 @@ variable "private_vlan_num" {
 variable "toolchain_template_repo" {
   type        = string
   description = "Compliance CI toolchain template repo"
-  default     = "https://github.ibm.com/open-toolchain/compliance-ci-toolchain"
+  default     = "https://us-south.git.cloud.ibm.com/open-toolchain/compliance-ci-toolchain"
 }
 
 variable "branch" {
@@ -162,12 +132,12 @@ variable "storage" {
   default     = "standard"
 }
 
-variable "github_token" {
-  type        = string
-  description = "A GitHub OAuth/Personal Access Token (https://github.ibm.com/settings/tokens)"
-}
-
 variable "ibmcloud_api_key" {
   type        = string
   description = "The IAM API Key for IBM Cloud access (https://cloud.ibm.com/iam/apikeys)"
+}
+
+variable "gitlab_token" {
+  type        = string
+  description = "A GitLab Personal Access Token (https://us-south.git.cloud.ibm.com/-/profile/personal_access_tokens)"
 }


### PR DESCRIPTION
With this update, I decided to just allow the DevOps template to create/clone/link the default repos for the user/customer. 